### PR TITLE
feat: add package exports for ingest modules, API, and dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,24 @@
     "url": "https://github.com/WilliamJudge94/oh-my-opencode-dashboard"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/server/start.ts",
+      "types": "./src/server/start.ts"
+    },
+    "./ingest": {
+      "import": "./src/ingest/index.ts",
+      "types": "./src/ingest/index.ts"
+    },
+    "./server/api": {
+      "import": "./src/server/api.ts",
+      "types": "./src/server/api.ts"
+    },
+    "./server/dashboard": {
+      "import": "./src/server/dashboard.ts",
+      "types": "./src/server/dashboard.ts"
+    }
+  },
   "bin": {
     "oh-my-opencode-dashboard": "./src/server/start.ts"
   },

--- a/src/ingest/index.ts
+++ b/src/ingest/index.ts
@@ -1,0 +1,56 @@
+export { deriveBackgroundTasks, type BackgroundTaskRow } from "./background-tasks"
+export { readBoulderState, readPlanProgress, readPlanSteps, type PlanStep, type BoulderState } from "./boulder"
+export { pickLatestModelString } from "./model"
+export { getOpenCodeStorageDir, realpathSafe, assertAllowedPath } from "./paths"
+export {
+  getMainSessionView,
+  getStorageRoots,
+  getMessageDir,
+  pickActiveSessionId,
+  readMainSessionMetas,
+  type MainSessionView,
+  type OpenCodeStorageRoots,
+  type SessionMetadata,
+  type StoredMessageMeta,
+  type StoredToolPart,
+} from "./session"
+export {
+  selectStorageBackend,
+  getOpenCodeSqlitePath,
+  isSqliteUsable,
+  readMainSessionMetasSqlite,
+  readAllSessionMetasSqlite,
+  readSessionExistsSqlite,
+  readRecentMessageMetasSqlite,
+  readToolPartsForMessagesSqlite,
+  readTodosSqlite,
+  getLegacyStorageRootForBackend,
+  type StorageBackend,
+  type FilesStorageBackend,
+  type SqliteStorageBackend,
+  type SqliteReadFailureReason,
+  type SqliteReadResult,
+  type TodoItem,
+} from "./storage-backend"
+export {
+  deriveBackgroundTasksSqlite,
+  deriveTimeSeriesActivitySqlite,
+  deriveTodosSqlite,
+  deriveTokenUsageSqlite,
+  deriveToolCallsSqlite,
+  getMainSessionViewSqlite,
+  pickActiveSessionIdSqlite,
+} from "./sqlite-derive"
+export {
+  loadRegistry,
+  addOrUpdateSource,
+  listSources,
+  getDefaultSourceId,
+  getSourceById,
+  type SourceRegistryEntry,
+  type SourceListItem,
+} from "./sources-registry"
+export { deriveTimeSeriesActivity, type TimeSeriesPayload } from "./timeseries"
+export { aggregateTokenUsage, type TokenUsageTotals, type TokenUsageRow } from "./token-usage-core"
+export { deriveTokenUsage } from "./token-usage"
+export { deriveToolCalls, MAX_TOOL_CALL_MESSAGES, MAX_TOOL_CALLS } from "./tool-calls"


### PR DESCRIPTION
## Summary

- Adds `exports` field to `package.json` exposing four entry points for programmatic consumption
- Creates `src/ingest/index.ts` barrel export re-exporting all public symbols from ingest modules

## Motivation

Downstream tools (e.g. [Arachne](https://github.com/IlliquidAsset/arachne)) want to import the data/ingest layer directly as a library rather than running the full Hono server. Currently the only way to consume the ingest modules is to vendor them. With package exports, consumers can do:

```ts
import { buildDashboardPayload } from 'oh-my-opencode-dashboard/server/dashboard'
import { selectStorageBackend, getStorageRoots } from 'oh-my-opencode-dashboard/ingest'
import { createApi } from 'oh-my-opencode-dashboard/server/api'
```

## Export Map

| Entry point | Resolves to |
|-------------|-------------|
| `oh-my-opencode-dashboard` | `./src/server/start.ts` (existing default) |
| `oh-my-opencode-dashboard/ingest` | `./src/ingest/index.ts` (new barrel) |
| `oh-my-opencode-dashboard/server/api` | `./src/server/api.ts` |
| `oh-my-opencode-dashboard/server/dashboard` | `./src/server/dashboard.ts` |

## Changes

1. **`package.json`** — added `exports` field with four entry points
2. **`src/ingest/index.ts`** — new barrel file re-exporting all public types and functions from the 12 ingest modules

## Verification

- All 168 existing tests pass (`bun test` — 0 failures)
- No changes to existing module code
- `files` field already includes `src/`, so exports are covered in published package